### PR TITLE
parallel plotting fix for setplot string.

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -148,7 +148,7 @@ class ClawPlotData(clawdata.ClawData):
 
         # Parallel capabilities
         # Run multiple processess dividing up the frames that need to be plotted
-        self.add_attribute('parallel', True)
+        self.add_attribute('parallel', False)
         # Default to OMP_NUM_THREADS available if defined
         self.add_attribute('num_procs', None)
         self.add_attribute('proc_frames', None)

--- a/src/python/visclaw/plotclaw.py
+++ b/src/python/visclaw/plotclaw.py
@@ -60,7 +60,15 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
     if plotdata.num_procs is None:
         plotdata.num_procs = int(os.environ.get("OMP_NUM_THREADS", 1))
 
-    if plotdata.parallel and plotdata.num_procs != 1:
+    # Make sure plotdata.parallel is False in some cases:
+
+    if plotdata.num_procs == 1:
+        plotdata.parallel = False   # not doing in parallel in this case
+
+    if type(setplot) is not str:
+        plotdata.parallel = False   # cannot call plotclaw from shell
+
+    if plotdata.parallel:
 
         # If this is the original call then we need to split up the work and 
         # call this function again

--- a/src/python/visclaw/plotclaw.py
+++ b/src/python/visclaw/plotclaw.py
@@ -62,13 +62,13 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
 
     # Make sure plotdata.parallel is False in some cases:
 
-    if plotdata.num_procs == 1:
-        plotdata.parallel = False   # not doing in parallel in this case
-
-    if type(setplot) is not str:
-        plotdata.parallel = False   # cannot call plotclaw from shell
 
     if plotdata.parallel:
+        assert type(setplot) in [str, bool, type(None)], \
+                "*** Parallel plotting is not supported when ClawPlotData " \
+                + "attribute setplot is a function."
+
+    if plotdata.parallel and (plotdata.num_procs > 1):
 
         # If this is the original call then we need to split up the work and 
         # call this function again

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -2691,6 +2691,9 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     from clawpack.visclaw.data import ClawPlotData
     from clawpack.visclaw import frametools, gaugetools, plotpages
 
+    # doing plots in parallel?
+    _parallel = plotdata.parallel and (plotdata.num_procs > 1) 
+
     if plotdata._parallel_todo == 'frames':
         # all we need to do is make png's for some frames in this case:
         for frameno in plotdata.print_framenos:
@@ -2800,7 +2803,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     framefiles = glob.glob(os.path.join(plotdir,'frame*.png')) + \
                     glob.glob(os.path.join(plotdir,'frame*.html'))
 
-    if (not plotdata.parallel) or (plotdata._parallel_todo=='initialize'):
+    if (not _parallel) or (plotdata._parallel_todo=='initialize'):
         if overwrite:
             # remove any old versions:
             for file in framefiles:
@@ -2919,7 +2922,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     else:
         print "Now making png files for all figures..."
 
-        if not plotdata.parallel:
+        if not _parallel:
             # don't create the png for frames when run in parallel
             # (unless plotdata._parallell_todo=='frames', handled earlier)
             for frameno in framenos:


### PR DESCRIPTION
To address problems raised in clawpack/visclaw#170.

plotdata.parallel must be False if only 1 thread or if setplot is a function rather than string.

**Note:** in `data.py` we set `plotdata.parallel = True` by default.  Perhaps it's more logical to set to `False` unless the user explicitly sets it to `True`?   The nice thing about the current default is that if `OMP_NUM_THREADS` is set, `make plots` will use this without having to change `setplot.py`, but maybe it's better to make this more explicit.
